### PR TITLE
Set up devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
+
+# System dependencies required to build and test:
+# - pkg-config + dbus headers for libdbus-sys (bluer)
+# - bluez/ble headers for bluer (libbluetooth-dev, libudev-dev)
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        pkg-config \
+        libdbus-1-dev \
+        libbluetooth-dev \
+        libudev-dev \
+        bluez \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "ruuvitag-listener",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteUser": "vscode",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "rust-analyzer.checkOnSave": true,
+        "rust-analyzer.check.command": "clippy",
+        "rust-analyzer.cargo.buildScripts.enable": true,
+        "files.watcherExclude": {
+          "**/target/**": true
+        },
+        "search.exclude": {
+          "**/target": true
+        }
+      },
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "serayuzgur.crates"
+      ]
+    }
+  },
+  "mounts": [
+    {
+      "source": "ruuvitag-listener-target",
+      "target": "/workspaces/${localWorkspaceFolderBasename}/target",
+      "type": "volume"
+    }
+  ],
+  "postCreateCommand": "rustc --version && cargo --version"
+}

--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 A command-line client to listen to [RuuviTag](https://ruuvi.com) sensor measurements over Bluetooth LE and output as [InfluxDB line protocol](https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_reference/).
 
+The listener understands RuuviTag data formats 5 and 6.
+
 The output can be used in e.g. [Telegraf Execd Input](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/execd). For an example setup, check out [examples/telegraf](./examples/telegraf/README.md).
 
 ## Requirements
 
 - RuuviTag Bluetooth sensor
 - Linux with BlueZ Bluetooth stack
+- DBus (for Bluetooth access via BlueZ)
 
 ## Installation
 


### PR DESCRIPTION
Set up devcontainers for development on non-Linux devices or without having dbus development libraries installed.