### PR TITLE
Add --throttle option to limit events emitted

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -117,6 +117,9 @@ mod tests {
             map.get(&Address([0x11, 0x22, 0x33, 0x44, 0x55, 0x66])),
             Some(&"Bedroom".to_string())
         );
-        assert_eq!(map.get(&Address([0x00, 0x00, 0x00, 0x00, 0x00, 0x00])), None);
+        assert_eq!(
+            map.get(&Address([0x00, 0x00, 0x00, 0x00, 0x00, 0x00])),
+            None
+        );
     }
 }

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -3,16 +3,17 @@
 //! This module provides functionality to map MAC addresses to human-readable names,
 //! making it easier to identify individual RuuviTag sensors in output.
 
-use std::collections::BTreeMap;
+use bluer::Address;
+use std::collections::HashMap;
 
-/// A type alias for MAC-to-name mappings.
-pub type AliasMap = BTreeMap<String, String>;
+/// A type alias for MAC-to-name mappings using efficient Address keys.
+pub type AliasMap = HashMap<Address, String>;
 
 /// A parsed alias mapping a MAC address to a human-readable name.
 #[derive(Debug, Clone)]
 pub struct Alias {
-    /// The MAC address (e.g., "AA:BB:CC:DD:EE:FF")
-    pub address: String,
+    /// The MAC address as an efficient 6-byte array
+    pub address: Address,
     /// The human-readable name (e.g., "Sauna")
     pub name: String,
 }
@@ -30,16 +31,22 @@ pub struct Alias {
 /// use ruuvitag_listener::alias::parse_alias;
 ///
 /// let alias = parse_alias("AA:BB:CC:DD:EE:FF=Kitchen").unwrap();
-/// assert_eq!(alias.address, "AA:BB:CC:DD:EE:FF");
+/// assert_eq!(alias.address.to_string(), "AA:BB:CC:DD:EE:FF");
 /// assert_eq!(alias.name, "Kitchen");
 /// ```
 pub fn parse_alias(src: &str) -> Result<Alias, String> {
-    src.split_once('=')
-        .map(|(address, name)| Alias {
-            address: address.into(),
-            name: name.into(),
-        })
-        .ok_or_else(|| "invalid alias: expected format MAC=NAME".into())
+    let (address_str, name) = src
+        .split_once('=')
+        .ok_or_else(|| "invalid alias: expected format MAC=NAME".to_string())?;
+
+    let address: Address = address_str
+        .parse()
+        .map_err(|_| format!("invalid MAC address: {}", address_str))?;
+
+    Ok(Alias {
+        address,
+        name: name.into(),
+    })
 }
 
 /// Convert a slice of Alias values into an AliasMap.
@@ -48,11 +55,11 @@ pub fn parse_alias(src: &str) -> Result<Alias, String> {
 /// * `aliases` - A slice of Alias structs
 ///
 /// # Returns
-/// A BTreeMap mapping MAC addresses to their human-readable names.
+/// A HashMap mapping MAC addresses to their human-readable names.
 pub fn to_map(aliases: &[Alias]) -> AliasMap {
     aliases
         .iter()
-        .map(|a| (a.address.clone(), a.name.clone()))
+        .map(|a| (a.address, a.name.clone()))
         .collect()
 }
 
@@ -65,7 +72,7 @@ mod tests {
         let result = parse_alias("AA:BB:CC:DD:EE:FF=Kitchen");
         assert!(result.is_ok());
         let alias = result.unwrap();
-        assert_eq!(alias.address, "AA:BB:CC:DD:EE:FF");
+        assert_eq!(alias.address, Address([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]));
         assert_eq!(alias.name, "Kitchen");
     }
 
@@ -78,8 +85,14 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_alias_invalid() {
+    fn test_parse_alias_invalid_format() {
         let result = parse_alias("no-equals-sign");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_alias_invalid_mac() {
+        let result = parse_alias("invalid-mac=Kitchen");
         assert!(result.is_err());
     }
 
@@ -87,17 +100,23 @@ mod tests {
     fn test_to_map() {
         let aliases = vec![
             Alias {
-                address: "AA:BB:CC:DD:EE:FF".to_string(),
+                address: Address([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
                 name: "Kitchen".to_string(),
             },
             Alias {
-                address: "11:22:33:44:55:66".to_string(),
+                address: Address([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]),
                 name: "Bedroom".to_string(),
             },
         ];
         let map = to_map(&aliases);
-        assert_eq!(map.get("AA:BB:CC:DD:EE:FF"), Some(&"Kitchen".to_string()));
-        assert_eq!(map.get("11:22:33:44:55:66"), Some(&"Bedroom".to_string()));
-        assert_eq!(map.get("00:00:00:00:00:00"), None);
+        assert_eq!(
+            map.get(&Address([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF])),
+            Some(&"Kitchen".to_string())
+        );
+        assert_eq!(
+            map.get(&Address([0x11, 0x22, 0x33, 0x44, 0x55, 0x66])),
+            Some(&"Bedroom".to_string())
+        );
+        assert_eq!(map.get(&Address([0x00, 0x00, 0x00, 0x00, 0x00, 0x00])), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,19 @@
 use clap::Parser;
 use std::io::Write;
 use std::panic::{self, PanicHookInfo};
+use std::time::Duration;
 
 mod alias;
 mod measurement;
 mod output;
 mod scanner;
+mod throttle;
 
 use alias::{Alias, parse_alias};
 use measurement::Measurement;
 use output::OutputFormatter;
 use output::influxdb::InfluxDbFormatter;
+use throttle::{Throttle, parse_duration};
 
 /// Exit codes for the application
 const EXIT_SUCCESS: i32 = 0;
@@ -32,6 +35,12 @@ struct Options {
     /// Verbose output, print parse errors for unrecognized data
     #[arg(short = 'v', long = "verbose")]
     verbose: bool,
+
+    /// Throttle events per tag to at most one per interval.
+    /// Accepts duration with suffix: 3s, 1m, 500ms, 2h.
+    /// Without suffix, value is interpreted as seconds.
+    #[arg(long, value_parser = parse_duration)]
+    throttle: Option<Duration>,
 }
 
 /// Print a formatted measurement to stdout.
@@ -55,8 +64,9 @@ fn print_measurement(
 /// This function:
 /// 1. Converts CLI aliases into a lookup map
 /// 2. Creates an InfluxDB formatter with the specified measurement name
-/// 3. Starts the BLE scanner
-/// 4. Processes measurements and outputs them to stdout until interrupted
+/// 3. Optionally creates a throttle to limit event frequency per tag
+/// 4. Starts the BLE scanner
+/// 5. Processes measurements and outputs them to stdout until interrupted
 ///
 /// # Arguments
 /// * `options` - Command-line options parsed from user input
@@ -67,12 +77,20 @@ async fn run(options: Options) -> Result<(), scanner::ScanError> {
     let aliases = alias::to_map(&options.alias);
     let formatter = InfluxDbFormatter::new(options.influxdb_measurement.clone(), aliases);
 
+    // Create throttle if interval is specified
+    let mut throttle = options.throttle.map(Throttle::new);
+
     let mut measurements = scanner::start_scan(options.verbose).await?;
 
     while let Some(result) = measurements.recv().await {
         match result {
             Ok(measurement) => {
-                if let Err(error) = print_measurement(&formatter, &measurement) {
+                // Check throttle before emitting
+                let should_emit = throttle
+                    .as_mut()
+                    .is_none_or(|t| t.should_emit(&measurement.mac));
+
+                if should_emit && let Err(error) = print_measurement(&formatter, &measurement) {
                     eprintln!("error: {}", error);
                     std::process::exit(EXIT_ERROR);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,10 +85,10 @@ async fn run(options: Options) -> Result<(), scanner::ScanError> {
     while let Some(result) = measurements.recv().await {
         match result {
             Ok(measurement) => {
-                // Check throttle before emitting
+                // Check throttle before emitting (Address is Copy, no allocation)
                 let should_emit = throttle
                     .as_mut()
-                    .is_none_or(|t| t.should_emit(&measurement.mac));
+                    .is_none_or(|t| t.should_emit(measurement.mac));
 
                 if should_emit && let Err(error) = print_measurement(&formatter, &measurement) {
                     eprintln!("error: {}", error);

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -1,3 +1,5 @@
+use bluer::Address;
+
 /// A measurement from a RuuviTag sensor.
 ///
 /// All values are in standard SI units:
@@ -13,8 +15,8 @@
 /// - Luminosity in lux
 #[derive(Debug, Clone, PartialEq)]
 pub struct Measurement {
-    /// MAC address of the RuuviTag
-    pub mac: String,
+    /// MAC address of the RuuviTag (stored as efficient 6-byte array)
+    pub mac: Address,
     /// Timestamp when the measurement was taken
     pub timestamp: std::time::SystemTime,
     /// Temperature in Celsius
@@ -53,7 +55,7 @@ mod tests {
     fn test_measurement_with_values() {
         let timestamp = std::time::SystemTime::now();
         let m = Measurement {
-            mac: "AA:BB:CC:DD:EE:FF".to_string(),
+            mac: Address([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
             timestamp,
             temperature: Some(25.5),
             humidity: Some(60.0),
@@ -89,7 +91,7 @@ mod tests {
     #[test]
     fn test_measurement_clone() {
         let m1 = Measurement {
-            mac: "AA:BB:CC:DD:EE:FF".to_string(),
+            mac: Address([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
             temperature: Some(25.5),
             humidity: None,
             pressure: None,

--- a/src/output/influxdb.rs
+++ b/src/output/influxdb.rs
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_field_value_display() {
-        assert_eq!(format!("{}", FieldValue::Float(3.14)), "3.14");
+        assert_eq!(format!("{}", FieldValue::Float(2.5)), "2.5");
         assert_eq!(
             format!("{}", FieldValue::String("test".to_string())),
             "\"test\""

--- a/src/output/influxdb.rs
+++ b/src/output/influxdb.rs
@@ -121,11 +121,7 @@ impl InfluxDbFormatter {
         tags.insert("mac".to_string(), address_str.clone());
 
         // Use alias if available, otherwise fall back to MAC address string
-        let name = self
-            .aliases
-            .get(&address)
-            .cloned()
-            .unwrap_or(address_str);
+        let name = self.aliases.get(&address).cloned().unwrap_or(address_str);
         tags.insert("name".to_string(), name);
 
         tags

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,0 +1,344 @@
+//! Event throttling for RuuviTag measurements.
+//!
+//! This module provides per-device throttling to limit how often measurements
+//! are emitted for each individual RuuviTag. This is useful for reducing output
+//! volume when tags broadcast frequently but data changes slowly.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// A throttle that limits the rate of events per device (identified by MAC address).
+///
+/// Each device is tracked independently, allowing at most one event per `interval`
+/// duration. The first event for a device is always allowed.
+#[derive(Debug)]
+pub struct Throttle {
+    /// Minimum time between events for each device
+    interval: Duration,
+    /// Last event time for each MAC address
+    last_seen: HashMap<String, Instant>,
+}
+
+impl Throttle {
+    /// Create a new throttle with the specified minimum interval between events.
+    ///
+    /// # Arguments
+    /// * `interval` - Minimum duration between events for each device
+    ///
+    /// # Example
+    /// ```
+    /// use std::time::Duration;
+    /// use ruuvitag_listener::throttle::Throttle;
+    ///
+    /// let throttle = Throttle::new(Duration::from_secs(3));
+    /// ```
+    pub fn new(interval: Duration) -> Self {
+        Throttle {
+            interval,
+            last_seen: HashMap::new(),
+        }
+    }
+
+    /// Check if an event from the given MAC address should be allowed.
+    ///
+    /// Returns `true` if enough time has passed since the last event from this
+    /// device (or if this is the first event). If `true` is returned, the
+    /// internal timer for this device is reset.
+    ///
+    /// # Arguments
+    /// * `mac` - The MAC address of the device
+    ///
+    /// # Returns
+    /// `true` if the event should be emitted, `false` if it should be throttled
+    pub fn should_emit(&mut self, mac: &str) -> bool {
+        let now = Instant::now();
+
+        match self.last_seen.get(mac) {
+            Some(last) if now.duration_since(*last) < self.interval => false,
+            _ => {
+                self.last_seen.insert(mac.to_string(), now);
+                true
+            }
+        }
+    }
+}
+
+/// Parse a duration from a human-readable string.
+///
+/// Supports the following suffixes:
+/// - `s` or no suffix: seconds
+/// - `m`: minutes  
+/// - `h`: hours
+/// - `ms`: milliseconds
+///
+/// # Arguments
+/// * `src` - A string like "3s", "1m", "500ms", or "30"
+///
+/// # Returns
+/// A Result containing the parsed Duration or an error message.
+///
+/// # Examples
+/// ```
+/// use ruuvitag_listener::throttle::parse_duration;
+/// use std::time::Duration;
+///
+/// assert_eq!(parse_duration("3s").unwrap(), Duration::from_secs(3));
+/// assert_eq!(parse_duration("1m").unwrap(), Duration::from_secs(60));
+/// assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+/// ```
+pub fn parse_duration(src: &str) -> Result<Duration, String> {
+    let src = src.trim();
+
+    if src.is_empty() {
+        return Err("empty duration string".to_string());
+    }
+
+    // Try parsing with different suffixes
+    if let Some(num) = src.strip_suffix("ms") {
+        let millis: u64 = num
+            .trim()
+            .parse()
+            .map_err(|_| format!("invalid milliseconds: {}", num))?;
+        return Ok(Duration::from_millis(millis));
+    }
+
+    if let Some(num) = src.strip_suffix('h') {
+        let hours: u64 = num
+            .trim()
+            .parse()
+            .map_err(|_| format!("invalid hours: {}", num))?;
+        return Ok(Duration::from_secs(hours * 3600));
+    }
+
+    if let Some(num) = src.strip_suffix('m') {
+        let minutes: u64 = num
+            .trim()
+            .parse()
+            .map_err(|_| format!("invalid minutes: {}", num))?;
+        return Ok(Duration::from_secs(minutes * 60));
+    }
+
+    if let Some(num) = src.strip_suffix('s') {
+        let secs: u64 = num
+            .trim()
+            .parse()
+            .map_err(|_| format!("invalid seconds: {}", num))?;
+        return Ok(Duration::from_secs(secs));
+    }
+
+    // No suffix, treat as seconds
+    let secs: u64 = src
+        .parse()
+        .map_err(|_| format!("invalid duration: {}", src))?;
+    Ok(Duration::from_secs(secs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_throttle_first_event_allowed() {
+        let mut throttle = Throttle::new(Duration::from_secs(1));
+        assert!(throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+    }
+
+    #[test]
+    fn test_throttle_immediate_second_event_blocked() {
+        let mut throttle = Throttle::new(Duration::from_secs(1));
+        assert!(throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+        assert!(!throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+    }
+
+    #[test]
+    fn test_throttle_different_devices_independent() {
+        let mut throttle = Throttle::new(Duration::from_secs(1));
+        assert!(throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+        assert!(throttle.should_emit("11:22:33:44:55:66"));
+        assert!(!throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+        assert!(!throttle.should_emit("11:22:33:44:55:66"));
+    }
+
+    #[test]
+    fn test_throttle_zero_interval() {
+        let mut throttle = Throttle::new(Duration::ZERO);
+        assert!(throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+        assert!(throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+    }
+
+    #[test]
+    fn test_throttle_allowed_after_interval_passes() {
+        let mut throttle = Throttle::new(Duration::from_millis(10));
+        assert!(throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+        assert!(!throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+
+        // Wait for the interval to pass
+        std::thread::sleep(Duration::from_millis(15));
+
+        // Should now be allowed again
+        assert!(throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+    }
+
+    #[test]
+    fn test_throttle_multiple_rapid_events_only_first_allowed() {
+        let mut throttle = Throttle::new(Duration::from_secs(1));
+        let mac = "AA:BB:CC:DD:EE:FF";
+
+        // First event allowed
+        assert!(throttle.should_emit(mac));
+
+        // All subsequent rapid events blocked
+        for _ in 0..10 {
+            assert!(!throttle.should_emit(mac));
+        }
+    }
+
+    #[test]
+    fn test_throttle_alternating_devices() {
+        let mut throttle = Throttle::new(Duration::from_secs(1));
+        let mac1 = "AA:BB:CC:DD:EE:FF";
+        let mac2 = "11:22:33:44:55:66";
+
+        // First events from each device allowed
+        assert!(throttle.should_emit(mac1));
+        assert!(throttle.should_emit(mac2));
+
+        // Alternating rapid events all blocked
+        assert!(!throttle.should_emit(mac1));
+        assert!(!throttle.should_emit(mac2));
+        assert!(!throttle.should_emit(mac1));
+        assert!(!throttle.should_emit(mac2));
+    }
+
+    #[test]
+    fn test_throttle_many_devices() {
+        let mut throttle = Throttle::new(Duration::from_secs(1));
+
+        // Create 100 different MAC addresses
+        let macs: Vec<String> = (0..100)
+            .map(|i| format!("{:02X}:{:02X}:CC:DD:EE:FF", i / 256, i % 256))
+            .collect();
+
+        // First event from each should be allowed
+        for mac in &macs {
+            assert!(
+                throttle.should_emit(mac),
+                "First event for {} should be allowed",
+                mac
+            );
+        }
+
+        // Second event from each should be blocked
+        for mac in &macs {
+            assert!(
+                !throttle.should_emit(mac),
+                "Second event for {} should be blocked",
+                mac
+            );
+        }
+    }
+
+    #[test]
+    fn test_throttle_empty_mac_address() {
+        let mut throttle = Throttle::new(Duration::from_secs(1));
+
+        // Empty string is a valid key
+        assert!(throttle.should_emit(""));
+        assert!(!throttle.should_emit(""));
+    }
+
+    #[test]
+    fn test_throttle_timer_resets_on_emit() {
+        let mut throttle = Throttle::new(Duration::from_millis(20));
+        let mac = "AA:BB:CC:DD:EE:FF";
+
+        assert!(throttle.should_emit(mac));
+
+        // Wait partial interval
+        std::thread::sleep(Duration::from_millis(15));
+        assert!(!throttle.should_emit(mac));
+
+        // Wait for full interval from first emit
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(throttle.should_emit(mac)); // Allowed - timer reset here
+
+        // Immediately after, should be blocked again
+        assert!(!throttle.should_emit(mac));
+    }
+
+    #[test]
+    fn test_throttle_blocked_event_does_not_reset_timer() {
+        let mut throttle = Throttle::new(Duration::from_millis(30));
+        let mac = "AA:BB:CC:DD:EE:FF";
+
+        assert!(throttle.should_emit(mac)); // t=0, timer starts
+
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(!throttle.should_emit(mac)); // t=10, blocked, timer NOT reset
+
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(!throttle.should_emit(mac)); // t=20, still blocked
+
+        std::thread::sleep(Duration::from_millis(15));
+        // t=35, now past the 30ms interval from t=0
+        assert!(throttle.should_emit(mac)); // Should be allowed
+    }
+
+    #[test]
+    fn test_throttle_case_sensitive_mac() {
+        let mut throttle = Throttle::new(Duration::from_secs(1));
+
+        // MAC addresses are case-sensitive (as strings)
+        assert!(throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+        assert!(throttle.should_emit("aa:bb:cc:dd:ee:ff")); // Different key
+
+        assert!(!throttle.should_emit("AA:BB:CC:DD:EE:FF"));
+        assert!(!throttle.should_emit("aa:bb:cc:dd:ee:ff"));
+    }
+
+    #[test]
+    fn test_parse_duration_seconds() {
+        assert_eq!(parse_duration("3s").unwrap(), Duration::from_secs(3));
+        assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_duration("0s").unwrap(), Duration::from_secs(0));
+    }
+
+    #[test]
+    fn test_parse_duration_minutes() {
+        assert_eq!(parse_duration("1m").unwrap(), Duration::from_secs(60));
+        assert_eq!(parse_duration("5m").unwrap(), Duration::from_secs(300));
+    }
+
+    #[test]
+    fn test_parse_duration_hours() {
+        assert_eq!(parse_duration("1h").unwrap(), Duration::from_secs(3600));
+        assert_eq!(parse_duration("2h").unwrap(), Duration::from_secs(7200));
+    }
+
+    #[test]
+    fn test_parse_duration_milliseconds() {
+        assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+        assert_eq!(
+            parse_duration("1000ms").unwrap(),
+            Duration::from_millis(1000)
+        );
+    }
+
+    #[test]
+    fn test_parse_duration_no_suffix() {
+        assert_eq!(parse_duration("10").unwrap(), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_parse_duration_with_whitespace() {
+        assert_eq!(parse_duration(" 3s ").unwrap(), Duration::from_secs(3));
+        assert_eq!(parse_duration("3 s").unwrap(), Duration::from_secs(3));
+    }
+
+    #[test]
+    fn test_parse_duration_invalid() {
+        assert!(parse_duration("").is_err());
+        assert!(parse_duration("abc").is_err());
+        assert!(parse_duration("-1s").is_err());
+    }
+}


### PR DESCRIPTION
Ruuvi Air Quality Monitors emit a lot of Bluetooth LE advertisements. To limit the volume of data collected, add option to define a quiet period after each event (i.e. a throttle). The default is no throttling.