### PR TITLE
Use single-threaded tokio runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,15 +442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,16 +571,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -855,7 +836,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "tokio-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2024"
 [dependencies]
 bluer = { version = "0.17", features = ["bluetoothd"] }
 ruuvi-decoders = "1.0"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+tokio = { version = "1", features = ["rt", "macros", "sync"] }
 futures = "0.3"
 clap = { version = "4", features = ["derive"] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ async fn run(options: Options) -> Result<(), scanner::ScanError> {
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     // Set up panic hook to ensure clean exit codes for process managers
     // (e.g., systemd, Telegraf execd) that monitor exit status


### PR DESCRIPTION
ruuvitag-listener is mostly idling and listening for I/O. As such, there isn't really benefit in running multi-threaded mode. Optimise by not having thread management overhead even if this is very limited.