### PR TITLE
Use thiserror for errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "futures",
  "libc",
  "ruuvi-decoders",
+ "thiserror",
  "tokio",
  "tokio-test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ruuvi-decoders = "1.0"
 tokio = { version = "1", features = ["rt", "macros", "sync"] }
 futures = { version = "0.3", optional = true }
 clap = { version = "4", features = ["derive"] }
+thiserror = "2"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,7 @@ use std::io;
 use std::io::Write;
 use std::pin::Pin;
 use std::time::Duration;
+use thiserror::Error;
 use tokio::sync::mpsc;
 
 /// Returns the default backend argument as a string for CLI.
@@ -114,33 +115,12 @@ pub struct Options {
 }
 
 /// Errors returned by the core run loop.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum RunError {
-    Scan(ScanError),
-    Io(io::Error),
-}
-
-impl std::fmt::Display for RunError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RunError::Scan(e) => write!(f, "{e}"),
-            RunError::Io(e) => write!(f, "{e}"),
-        }
-    }
-}
-
-impl std::error::Error for RunError {}
-
-impl From<ScanError> for RunError {
-    fn from(value: ScanError) -> Self {
-        RunError::Scan(value)
-    }
-}
-
-impl From<io::Error> for RunError {
-    fn from(value: io::Error) -> Self {
-        RunError::Io(value)
-    }
+    #[error(transparent)]
+    Scan(#[from] ScanError),
+    #[error(transparent)]
+    Io(#[from] io::Error),
 }
 
 /// Scanner abstraction to enable deterministic unit tests without Bluetooth hardware.


### PR DESCRIPTION
Remove repetitive code for formatting errors. Use thiserror crate instead.