### PR TITLE
Optimise and harden InfluxDB formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +159,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -184,6 +232,73 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "custom_debug"
@@ -285,6 +400,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "fnv"
@@ -394,10 +515,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -415,10 +553,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -531,6 +689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +733,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +785,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,12 +856,22 @@ version = "0.6.1"
 dependencies = [
  "bluer",
  "clap",
+ "criterion",
  "futures",
  "libc",
  "ruuvi-decoders",
  "thiserror",
  "tokio",
  "tokio-test",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -753,6 +1004,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +1087,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +1154,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1052,6 +1342,26 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ thiserror = "2"
 
 [dev-dependencies]
 tokio-test = "0.4"
+criterion = "0.5"
+tokio = { version = "1", features = ["rt-multi-thread"] }
+
+[[bench]]
+name = "pipeline"
+harness = false
 
 [profile.release]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 name = "pipeline"
 harness = false
 
+[[bench]]
+name = "formatter"
+harness = false
+
 [profile.release]
 opt-level = "s"
 lto = true

--- a/benches/formatter.rs
+++ b/benches/formatter.rs
@@ -1,0 +1,122 @@
+//! Benchmark suite specifically for the InfluxDB formatter.
+//!
+//! Isolates formatter performance from async runtime overhead to enable
+//! precise measurement and optimization of the formatting logic.
+
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use ruuvitag_listener::{InfluxDbFormatter, MacAddress, Measurement, OutputFormatter};
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+const TEST_MAC: MacAddress = MacAddress([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+
+/// V5-style measurement (standard RuuviTag with acceleration)
+fn v5_measurement() -> Measurement {
+    Measurement {
+        mac: TEST_MAC,
+        timestamp: SystemTime::UNIX_EPOCH,
+        temperature: Some(24.30),
+        humidity: Some(53.49),
+        pressure: Some(100044.0),
+        battery: Some(2.977),
+        tx_power: Some(4),
+        movement_counter: Some(66),
+        measurement_sequence: Some(205),
+        acceleration: Some((0.004, -0.004, 1.036)),
+        pm2_5: None,
+        co2: None,
+        voc_index: None,
+        nox_index: None,
+        luminosity: None,
+    }
+}
+
+/// V6-style measurement (Ruuvi Air Quality Monitor)
+fn v6_measurement() -> Measurement {
+    Measurement {
+        mac: TEST_MAC,
+        timestamp: SystemTime::UNIX_EPOCH,
+        temperature: Some(23.12),
+        humidity: Some(55.68),
+        pressure: Some(100798.0),
+        battery: None,
+        tx_power: None,
+        movement_counter: None,
+        measurement_sequence: Some(1),
+        acceleration: None,
+        pm2_5: Some(11.2),
+        co2: Some(473.0),
+        voc_index: Some(100.0),
+        nox_index: Some(1.0),
+        luminosity: Some(25.5),
+    }
+}
+/// Benchmark formatter with different measurement types
+fn bench_format_measurement_types(c: &mut Criterion) {
+    let mut group = c.benchmark_group("format_measurement_type");
+    let formatter = InfluxDbFormatter::new("ruuvi_measurement".to_string(), HashMap::new());
+
+    group.throughput(Throughput::Elements(1));
+
+    let v5 = v5_measurement();
+    group.bench_function("v5", |b| {
+        b.iter(|| {
+            let output = formatter.format(black_box(&v5));
+            black_box(output)
+        })
+    });
+
+    let v6 = v6_measurement();
+    group.bench_function("v6", |b| {
+        b.iter(|| {
+            let output = formatter.format(black_box(&v6));
+            black_box(output)
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmark with and without aliases
+fn bench_format_alias_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("format_alias_lookup");
+    let measurement = v5_measurement();
+
+    group.throughput(Throughput::Elements(1));
+
+    // No aliases
+    let formatter_no_alias =
+        InfluxDbFormatter::new("ruuvi_measurement".to_string(), HashMap::new());
+    group.bench_function("no_alias", |b| {
+        b.iter(|| {
+            let output = formatter_no_alias.format(black_box(&measurement));
+            black_box(output)
+        })
+    });
+
+    // With alias for this MAC
+    let mut aliases = HashMap::new();
+    aliases.insert(TEST_MAC, "Living_Room".to_string());
+    let formatter_with_alias = InfluxDbFormatter::new("ruuvi_measurement".to_string(), aliases);
+    group.bench_function("with_alias", |b| {
+        b.iter(|| {
+            let output = formatter_with_alias.format(black_box(&measurement));
+            black_box(output)
+        })
+    });
+
+    // With many aliases (but not for this MAC - tests lookup miss)
+    let mut many_aliases = HashMap::new();
+    for i in 0..100u8 {
+        let mac = MacAddress([0x00, 0x00, 0x00, 0x00, 0x00, i]);
+        many_aliases.insert(mac, format!("Device_{}", i));
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_format_measurement_types,
+    bench_format_alias_lookup
+);
+criterion_main!(benches);

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -1,0 +1,255 @@
+//! Integration benchmark for the RuuviTag processing pipeline.
+//!
+//! Benchmarks the full application loop using the same patterns as the
+//! integration tests in app.rs - with a FakeScanner feeding measurements
+//! through run_with_io.
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use ruuvitag_listener::app::{Options, Scanner, run_with_io};
+use ruuvitag_listener::{Backend, MacAddress, MeasurementResult, ScanError, decode_ruuvi_data};
+use std::future::Future;
+use std::pin::Pin;
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc;
+
+/// Example V5 payload (RuuviTag standard format)
+fn v5_payload() -> Vec<u8> {
+    vec![
+        0x05, // Format 5
+        0x12, 0xFC, // Temperature: 24.30°C
+        0x53, 0x94, // Humidity: 53.49%
+        0xC3, 0x7C, // Pressure: 100044 Pa
+        0x00, 0x04, // Acceleration X: 4 mG
+        0xFF, 0xFC, // Acceleration Y: -4 mG
+        0x04, 0x0C, // Acceleration Z: 1036 mG
+        0xAC, 0x36, // Battery: 2977 mV, TX Power: 4 dBm
+        0x42, // Movement counter: 66
+        0x00, 0xCD, // Sequence: 205
+        0xCB, 0xB8, 0x33, 0x4C, 0x88, 0x4F, // MAC address
+    ]
+}
+
+/// Example V6 payload (Ruuvi Air Quality Sensor)
+fn v6_payload() -> Vec<u8> {
+    vec![
+        0x06, 0x17, 0x0C, 0x56, 0x68, 0xC7, 0x9E, 0x00, 0x70, 0x00, 0xC9, 0x05, 0x01, 0xD9, 0xFF,
+        0xCD, 0x00, 0x4C, 0x88, 0x4F,
+    ]
+}
+
+const TEST_MAC: MacAddress = MacAddress([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+
+/// A fake scanner that yields pre-decoded measurements, similar to the one in app.rs tests.
+struct FakeScanner {
+    results: Vec<MeasurementResult>,
+}
+
+impl FakeScanner {
+    fn new(results: Vec<MeasurementResult>) -> Self {
+        Self { results }
+    }
+
+    /// Create a scanner that decodes raw payloads into measurements
+    fn from_raw_payloads(payloads: Vec<Vec<u8>>) -> Self {
+        let results = payloads
+            .into_iter()
+            .map(|data| decode_ruuvi_data(TEST_MAC, &data))
+            .collect();
+        Self::new(results)
+    }
+}
+
+impl Scanner for FakeScanner {
+    fn start_scan(
+        &self,
+        _backend: Backend,
+        _verbose: bool,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<mpsc::Receiver<MeasurementResult>, ScanError>> + Send + '_>,
+    > {
+        let results = self.results.clone();
+        Box::pin(async move {
+            let (tx, rx) = mpsc::channel::<MeasurementResult>(results.len().max(1));
+            tokio::spawn(async move {
+                for r in results {
+                    let _ = tx.send(r).await;
+                }
+            });
+            Ok(rx)
+        })
+    }
+}
+
+fn default_options() -> Options {
+    Options {
+        influxdb_measurement: "ruuvi_measurement".to_string(),
+        aliases: vec![],
+        verbose: false,
+        throttle: None,
+        backend: Backend::Bluer,
+    }
+}
+
+/// Benchmark the full application pipeline: scanner -> decode -> throttle -> format -> write
+fn bench_app_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("app_pipeline");
+    let rt = Runtime::new().unwrap();
+
+    // Single V5 measurement through the full pipeline
+    let v5_data = v5_payload();
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("single_v5", |b| {
+        b.iter(|| {
+            let scanner = FakeScanner::from_raw_payloads(vec![v5_data.clone()]);
+            let options = default_options();
+            let mut out = Vec::<u8>::with_capacity(512);
+            let mut err = Vec::<u8>::new();
+
+            rt.block_on(async {
+                run_with_io(options, &scanner, &mut out, &mut err)
+                    .await
+                    .unwrap();
+            });
+
+            black_box(out)
+        })
+    });
+
+    // Single V6 measurement
+    let v6_data = v6_payload();
+    group.bench_function("single_v6", |b| {
+        b.iter(|| {
+            let scanner = FakeScanner::from_raw_payloads(vec![v6_data.clone()]);
+            let options = default_options();
+            let mut out = Vec::<u8>::with_capacity(512);
+            let mut err = Vec::<u8>::new();
+
+            rt.block_on(async {
+                run_with_io(options, &scanner, &mut out, &mut err)
+                    .await
+                    .unwrap();
+            });
+
+            black_box(out)
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmark batch processing through the full pipeline
+fn bench_batch_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batch_pipeline");
+    let rt = Runtime::new().unwrap();
+
+    let v5_data = v5_payload();
+
+    for batch_size in [1, 10, 100] {
+        group.throughput(Throughput::Elements(batch_size as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(batch_size),
+            &batch_size,
+            |b, &size| {
+                let payloads: Vec<Vec<u8>> = (0..size).map(|_| v5_data.clone()).collect();
+
+                b.iter(|| {
+                    let scanner = FakeScanner::from_raw_payloads(payloads.clone());
+                    let options = default_options();
+                    let mut out = Vec::<u8>::with_capacity(512 * size);
+                    let mut err = Vec::<u8>::new();
+
+                    rt.block_on(async {
+                        run_with_io(options, &scanner, &mut out, &mut err)
+                            .await
+                            .unwrap();
+                    });
+
+                    black_box(out)
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark with throttling enabled (realistic scenario where most measurements are dropped)
+fn bench_throttled_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("throttled_pipeline");
+    let rt = Runtime::new().unwrap();
+
+    let v5_data = v5_payload();
+
+    // 100 measurements from the same MAC, but throttle is set to 1 hour
+    // so only the first one should be emitted
+    let payloads: Vec<Vec<u8>> = (0..100).map(|_| v5_data.clone()).collect();
+
+    group.throughput(Throughput::Elements(100));
+    group.bench_function("100_same_mac_throttled", |b| {
+        b.iter(|| {
+            let scanner = FakeScanner::from_raw_payloads(payloads.clone());
+            let mut options = default_options();
+            options.throttle = Some(std::time::Duration::from_secs(3600));
+
+            let mut out = Vec::<u8>::with_capacity(512);
+            let mut err = Vec::<u8>::new();
+
+            rt.block_on(async {
+                run_with_io(options, &scanner, &mut out, &mut err)
+                    .await
+                    .unwrap();
+            });
+
+            // Verify only 1 line was output (the rest were throttled)
+            debug_assert_eq!(out.iter().filter(|&&b| b == b'\n').count(), 1);
+
+            black_box(out)
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmark with multiple different devices (no throttling effect)
+fn bench_multi_device_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("multi_device_pipeline");
+    let rt = Runtime::new().unwrap();
+
+    // Pre-decode measurements from different MAC addresses
+    let v5_data = v5_payload();
+    let measurements: Vec<MeasurementResult> = (0..10u8)
+        .map(|i| {
+            let mac = MacAddress([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, i]);
+            decode_ruuvi_data(mac, &v5_data)
+        })
+        .collect();
+
+    group.throughput(Throughput::Elements(10));
+    group.bench_function("10_different_devices", |b| {
+        b.iter(|| {
+            let scanner = FakeScanner::new(measurements.clone());
+            let options = default_options();
+            let mut out = Vec::<u8>::with_capacity(512 * 10);
+            let mut err = Vec::<u8>::new();
+
+            rt.block_on(async {
+                run_with_io(options, &scanner, &mut out, &mut err)
+                    .await
+                    .unwrap();
+            });
+
+            black_box(out)
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_app_pipeline,
+    bench_batch_pipeline,
+    bench_throttled_pipeline,
+    bench_multi_device_pipeline,
+);
+criterion_main!(benches);

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -63,6 +63,18 @@ pub fn to_map(aliases: &[Alias]) -> AliasMap {
         .collect()
 }
 
+/// Resolve a device name from aliases, falling back to the MAC address string.
+///
+/// # Arguments
+/// * `mac` - The MAC address to resolve
+/// * `aliases` - The alias map to look up
+///
+/// # Returns
+/// The alias name if found, otherwise the MAC address formatted as a string.
+pub fn resolve_name(mac: &MacAddress, aliases: &AliasMap) -> String {
+    aliases.get(mac).cloned().unwrap_or_else(|| mac.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,5 +127,20 @@ mod tests {
             map.get(&MacAddress([0x00, 0x00, 0x00, 0x00, 0x00, 0x00])),
             None
         );
+    }
+
+    #[test]
+    fn resolve_name_returns_alias_when_present() {
+        let mut aliases = HashMap::new();
+        aliases.insert(TEST_MAC, "Sauna".to_string());
+
+        assert_eq!(resolve_name(&TEST_MAC, &aliases), "Sauna");
+    }
+
+    #[test]
+    fn resolve_name_returns_mac_when_no_alias() {
+        let aliases = HashMap::new();
+
+        assert_eq!(resolve_name(&TEST_MAC, &aliases), "AA:BB:CC:DD:EE:FF");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod throttle;
 pub(crate) mod test_utils;
 
 // Re-export commonly used types at the crate root
-pub use alias::{Alias, AliasMap, parse_alias, to_map};
+pub use alias::{Alias, AliasMap, parse_alias, resolve_name, to_map};
 pub use mac_address::MacAddress;
 pub use measurement::Measurement;
 pub use output::OutputFormatter;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -12,13 +12,17 @@ use crate::measurement::Measurement;
 ///
 /// Implementations of this trait convert a `Measurement` into a formatted string
 /// suitable for a specific output format (e.g., InfluxDB line protocol, JSON, CSV).
+///
+/// The `name` parameter is the resolved device name (either an alias or the MAC address),
+/// determined by the caller. This keeps formatters simple and free of alias handling logic.
 pub trait OutputFormatter: Send + Sync {
     /// Format a measurement.
     ///
     /// # Arguments
     /// * `measurement` - The measurement data to format (includes timestamp)
+    /// * `name` - The resolved device name (alias or MAC address)
     ///
     /// # Returns
     /// A formatted string representation of the measurement
-    fn format(&self, measurement: &Measurement) -> String;
+    fn format(&self, measurement: &Measurement, name: &str) -> String;
 }


### PR DESCRIPTION
## Summary

Optimizes the InfluxDB formatter by eliminating intermediate allocations, implementing proper escaping for edge cases, and adding performance optimizations. Refactors the API to accept device name as a parameter, separating alias resolution from formatting logic.

## Key Changes

### Performance Optimizations

- **Removed intermediate allocations**: Eliminated `BTreeMap` allocations by writing tags/fields directly to a pre-sized buffer (~300 bytes)
- **Fast-path escaping**: Added zero-allocation fast path when no special characters are present (common case)
- **Precomputed escape flag**: Measurement name escape requirement is computed once at initialization, avoiding repeated checks

### Edge Case Handling

- **Proper escaping**: Implements InfluxDB line protocol escaping for special characters:
  - Measurement names: escapes commas and spaces
  - Tag values: escapes commas, equals signs, and spaces
- **Comprehensive tests**: Added 9 edge case tests covering spaces, commas, equals signs, and empty strings

## Breaking Change

`OutputFormatter::format` signature changed:
- **Before**: `fn format(&self, measurement: &Measurement) -> String`
- **After**: `fn format(&self, measurement: &Measurement, name: &str) -> String`

This change requires callers to resolve device names (aliases) before calling the formatter.
